### PR TITLE
Updated URL for bootstrap to prevent mixed-mode blocking when using S…

### DIFF
--- a/base.twig
+++ b/base.twig
@@ -5,7 +5,7 @@
     {% block head %}
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <!-- Latest compiled + minified Bootstrap via CDN -->
-        <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css">
+        <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css">
         <link rel="stylesheet" href="{{ app.request.baseUrl }}/resources/css/stickyfooter.css">
         <link rel="stylesheet" href="{{ app.request.baseUrl }}/resources/css/stephcook.css">
         {% block css %}{% endblock %}


### PR DESCRIPTION
Found a problem when enabling SSL for your site via CloudFlare on the new server, browser wouldn't load bootstrap as hard coded for HTTP so mixed mode error.
